### PR TITLE
Extend Android templates

### DIFF
--- a/workflow-templates/android/gcx-android-publish.properties.json
+++ b/workflow-templates/android/gcx-android-publish.properties.json
@@ -1,6 +1,6 @@
 {
     "name": "gcx Android Publish Artifact",
-    "description": "Publish an artifact from an Android repository @ gcx using maven-publish",
+    "description": "Publish an artifact of an Android library repository @ gcx using maven-publish",
     "iconName": "gcx-icon",
     "categories": [
         "Gradle",

--- a/workflow-templates/android/gcx-android-publish.yml
+++ b/workflow-templates/android/gcx-android-publish.yml
@@ -2,7 +2,7 @@
 # to a Maven repository like GitHub Packages using the maven-publish plugin
 # It is triggered by the creation of a GitHub release
 # Please note that the KeyStore credentials have to be created as secrets in your project
-# e.g. by using the GitHub CLI tool
+# e.g. by using the GitHub CLI tool (https://cli.github.com/manual/gh_secret_set)
 # For more information about how to configure your project to use this, see:
 # https://wiki.gcxi.de/display/TENG/Using+GitHub+Packages+for+Android+Projects
 

--- a/workflow-templates/android/gcx-android-publish.yml
+++ b/workflow-templates/android/gcx-android-publish.yml
@@ -1,3 +1,9 @@
+# This workflow publishes a release build of e.g. a library project 
+# to a Maven repository like GitHub Packages using the maven-publish plugin
+# It is triggered by the creation of a GitHub release
+# For more information about how to configure your project to use this, see:
+# https://wiki.gcxi.de/display/TENG/Using+GitHub+Packages+for+Android+Projects
+
 name: Publish Artifact
 
 on:

--- a/workflow-templates/android/gcx-android-publish.yml
+++ b/workflow-templates/android/gcx-android-publish.yml
@@ -1,6 +1,8 @@
 # This workflow publishes a release build of e.g. a library project 
 # to a Maven repository like GitHub Packages using the maven-publish plugin
 # It is triggered by the creation of a GitHub release
+# Please note that the KeyStore credentials have to be created as secrets in your project
+# e.g. by using the GitHub CLI tool
 # For more information about how to configure your project to use this, see:
 # https://wiki.gcxi.de/display/TENG/Using+GitHub+Packages+for+Android+Projects
 

--- a/workflow-templates/android/gcx-android-pull-request.properties.json
+++ b/workflow-templates/android/gcx-android-pull-request.properties.json
@@ -1,6 +1,6 @@
 {
     "name": "gcx Android Pull Request",
-    "description": "Build a basic Pull Request for an Android repository @ gcx",
+    "description": "Build, test and analyze a Pull Request of an Android repository @ gcx",
     "iconName": "gcx-icon",
     "categories": [
         "Gradle",

--- a/workflow-templates/android/gcx-android-pull-request.yml
+++ b/workflow-templates/android/gcx-android-pull-request.yml
@@ -1,3 +1,10 @@
+# This workflow checks if the project can be built correctly and runs its unit tests and linter
+# After the tests have run it prints a report in the logs and uploads a report as workflow artifact
+# This workflow only runs if a Pull Request is (re-)opened and it is not a draft 
+# or after a push to develop or the default branch
+# For more information about best practices, see:
+# https://wiki.gcxi.de/display/TENG/GitHub+Actions%3A+Best+Practices
+
 name: Pull Request
 
 on:

--- a/workflow-templates/android/gcx-android-release.yml
+++ b/workflow-templates/android/gcx-android-release.yml
@@ -1,7 +1,7 @@
 # This workflow builds the release variant of the project and uploads it to the release 
 # It is triggered by the creation of a GitHub release
 # Please note that the KeyStore credentials have to be created as secrets in your project
-# e.g. by using the GitHub CLI tool
+# e.g. by using the GitHub CLI tool (https://cli.github.com/manual/gh_secret_set)
 # For more information about best practices, see:
 # https://wiki.gcxi.de/display/TENG/GitHub+Actions%3A+Best+Practices
 

--- a/workflow-templates/android/gcx-android-release.yml
+++ b/workflow-templates/android/gcx-android-release.yml
@@ -1,3 +1,8 @@
+# This workflow builds the release variant of the project after a GitHub release was created
+# The build artifact is uploaded as release artifact
+# For more information about best practices, see:
+# https://wiki.gcxi.de/display/TENG/GitHub+Actions%3A+Best+Practices
+
 name: Build Release
 
 on:

--- a/workflow-templates/android/gcx-android-release.yml
+++ b/workflow-templates/android/gcx-android-release.yml
@@ -1,5 +1,7 @@
-# This workflow builds the release variant of the project after a GitHub release was created
-# The build artifact is uploaded as release artifact
+# This workflow builds the release variant of the project and uploads it to the release 
+# It is triggered by the creation of a GitHub release
+# Please note that the KeyStore credentials have to be created as secrets in your project
+# e.g. by using the GitHub CLI tool
 # For more information about best practices, see:
 # https://wiki.gcxi.de/display/TENG/GitHub+Actions%3A+Best+Practices
 

--- a/workflow-templates/android/gcx-android-release.yml
+++ b/workflow-templates/android/gcx-android-release.yml
@@ -35,8 +35,17 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           ALIAS_PASSWORD: ${{ secrets.ALIAS_PASSWORD }}
         timeout-minutes: 10
-      - name: Upload build outputs
-        uses: actions/upload-artifact@v2
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@v1.2.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload release binary
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: release-outputs
-          path: 'app/build/outputs/'
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: app/build/outputs/apk/release/app-release.apk
+          asset_name: APK
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
Adds documentation on top of the workflows. Also uploads the release artifact to the GitHub release instead of uploading it as workflow artifact