### PR TITLE
Bugfix: Android Pull-Request Workflow is marked as not valid

### DIFF
--- a/.github/workflows/check-workflows.yml
+++ b/.github/workflows/check-workflows.yml
@@ -1,0 +1,55 @@
+# This workflow checks the other workflows in this repository, 
+# e.g. for Pull Requests, Releases etc., for their correctness
+# It is only triggered when changes are made to the workflows
+# For more information about best practices, see:
+# https://wiki.gcxi.de/display/TENG/GitHub+Actions%3A+Best+Practices
+
+name: Workflow Check
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'workflow-templates/**'
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+    paths:
+      - 'workflow-templates/**'
+
+jobs:
+  runAction:
+    name: Test Workflows
+    if: github.event_name == 'push' || !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project files
+        uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v2.1.5
+        with:
+          node-version: '12.x'
+      - name: Check Android PR Workflow
+        id: android-pr
+        uses: GCX-HCI/grandcentrix-actions-validator@v0.1.5
+        with:
+          file: ${{ github.workspace }}/workflow-templates/android/gcx-android-pull-request.yml
+      - name: Check Android Release Workflow
+        id: android-release
+        uses: GCX-HCI/grandcentrix-actions-validator@v0.1.5
+        with:
+          file: ${{ github.workspace }}/workflow-templates/android/gcx-android-release.yml
+      - name: Check Android Release by Tag Workflow
+        id: android-release-tag
+        uses: GCX-HCI/grandcentrix-actions-validator@v0.1.5
+        with:
+          file: ${{ github.workspace }}/workflow-templates/android/gcx-android-release-tag.yml
+      - name: Check Android Publish Workflow
+        id: android-publish
+        uses: GCX-HCI/grandcentrix-actions-validator@v0.1.5
+        with:
+          file: ${{ github.workspace }}/workflow-templates/android/gcx-android-publish.yml
+      - name: Check results
+        if: steps.android-pr.outcome != 'success' || steps.android-release.outcome != 'success' || steps.android-release-tag.outcome != 'success' || steps.android-publish.outcome != 'success'
+        run: |
+          echo "At least one of the workflow checks failed. Will fail this job now"
+          exit 1

--- a/workflow-templates/android/gcx-android-pull-request.yml
+++ b/workflow-templates/android/gcx-android-pull-request.yml
@@ -82,6 +82,7 @@ jobs:
         uses: mikepenz/action-junit-report@v2.2.0
         with:
           report_paths: '**/build/test-results/**/TEST-*.xml'
+          token: ${{ secrets.GITHUB_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Annotate PR with Lint Report
         uses: yutailang0119/action-android-lint@v1.0.2


### PR DESCRIPTION
#### Description:
The `mikepenz/action-junit-report@v2.2.0` action deprecated its input parameter `GITHUB_TOKEN` in favor of `TOKEN`.
Unfortunately it marked both of them as mandatory. Github does not check if all mandatory inputs are given and the action works if one is given.
But the Workflow Validator complains when not both are given.

So an easy workaround is to define both.

#### How to test:
See that the new Workflow Validation Check is successful.