### PR TITLE
Make ci fail on lint or test failure

### DIFF
--- a/workflow-templates/gcx-android-pull-request.yml
+++ b/workflow-templates/gcx-android-pull-request.yml
@@ -68,22 +68,22 @@ jobs:
         run: ./gradlew compileDebugUnitTests
       - name: Run tests
         run: ./gradlew testDebugUnitTest --continue
-        continue-on-error: true
         timeout-minutes: 10
-      - name: Run lint
-        run: ./gradlew lintDebug
-        continue-on-error: true
-        timeout-minutes: 5
       - name: Annotate PR with JUnit Report
         uses: mikepenz/action-junit-report@v2.2.0
+        if: always() # always run even if the previous step fails
         with:
           report_paths: '**/build/test-results/**/TEST-*.xml'
           token: ${{ secrets.GITHUB_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run lint
+        run: ./gradlew lintDebug
+        timeout-minutes: 5
       - name: Annotate PR with Lint Report
         uses: yutailang0119/action-android-lint@v1.0.2
+        if: always() # always run even if the previous step fails
         with:
-          xml_path: app/build/reports/lint-results-debug.xml
+          xml_path: '**/build/reports/lint-results-debug.xml'
       - name: Upload test and lint reports
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
## No Jira-Ticket

#### Description:
If tests or linting fail, the job should also fail. Currently the `continue-on-error` flag prevents a job from failing.