### PR TITLE
Replace deprecated actions

### DIFF
--- a/workflow-templates/gcx-android-publish.yml
+++ b/workflow-templates/gcx-android-publish.yml
@@ -29,15 +29,8 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: 8
-      - name: Cache gradle wrapper and packages
-        uses: actions/cache@v3.0.11
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@16bf8bc8fe830fa669c3c9f914d3eb147c629707 # v4.0.1
       - name: Build release
         run: ./gradlew assembleRelease
         timeout-minutes: 10

--- a/workflow-templates/gcx-android-pull-request.yml
+++ b/workflow-templates/gcx-android-pull-request.yml
@@ -30,15 +30,8 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: 8
-      - name: Cache gradle wrapper and packages
-        uses: actions/cache@v3.0.11
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@16bf8bc8fe830fa669c3c9f914d3eb147c629707 # v4.0.1
       - name: Build all variants
         run: ./gradlew assemble
         timeout-minutes: 10
@@ -55,15 +48,8 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: 8
-      - name: Cache gradle wrapper and packages
-        uses: actions/cache@v3.0.11
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@16bf8bc8fe830fa669c3c9f914d3eb147c629707 # v4.0.1
       - name: Compile tests
         run: ./gradlew compileDebugUnitTests
       - name: Run tests

--- a/workflow-templates/gcx-android-pull-request.yml
+++ b/workflow-templates/gcx-android-pull-request.yml
@@ -65,11 +65,6 @@ jobs:
       - name: Run lint
         run: ./gradlew lintDebug
         timeout-minutes: 5
-      - name: Annotate PR with Lint Report
-        uses: yutailang0119/action-android-lint@v3.1.0
-        if: always() # always run even if the previous step fails
-        with:
-          xml_path: '**/build/reports/lint-results-debug.xml'
       - name: Upload test and lint reports
         uses: actions/upload-artifact@v2
         with:

--- a/workflow-templates/gcx-android-release-tag.yml
+++ b/workflow-templates/gcx-android-release-tag.yml
@@ -28,15 +28,8 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: 8
-      - name: Cache gradle wrapper and packages
-        uses: actions/cache@v3.0.11
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@16bf8bc8fe830fa669c3c9f914d3eb147c629707 # v4.0.1
       - name: Build Release
         run: ./gradlew assembleRelease
         env:

--- a/workflow-templates/gcx-android-release-tag.yml
+++ b/workflow-templates/gcx-android-release-tag.yml
@@ -38,19 +38,11 @@ jobs:
         timeout-minutes: 10
       - name: Create github release
         id: github_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
         with:
           tag_name: ${GITHUB_REF#refs/*/}
-          release_name: Release $(cat app/build.gradle | grep 'versionName ' | sed -e "s/^.*[[:blank:]]//" -e "s/^\"//" -e "s/\"$//")
-          body: <MY RELEASE NOTES>
-      - name: Upload release binary
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.github_release.outputs.upload_url }}
-          asset_path: app/build/outputs/apk/release/app-release.apk
-          asset_name: app-release.apk
-          asset_content_type: application/octet-stream
+          name: Release $(cat app/build.gradle | grep 'versionName ' | sed -e "s/^.*[[:blank:]]//" -e "s/^\"//" -e "s/\"$//")
+          prerelease: false
+          generate_release_notes: true
+          files: |
+            app/build/outputs/apk/release/app-release.apk

--- a/workflow-templates/gcx-android-release.yml
+++ b/workflow-templates/gcx-android-release.yml
@@ -26,15 +26,8 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: 8
-      - name: Cache gradle wrapper and packages
-        uses: actions/cache@v3.0.11
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@16bf8bc8fe830fa669c3c9f914d3eb147c629707 # v4.0.1
       - name: Build Release
         run: ./gradlew assembleRelease
         env:

--- a/workflow-templates/gcx-android-release.yml
+++ b/workflow-templates/gcx-android-release.yml
@@ -40,11 +40,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload release binary
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        id: github_release
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
         with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: app/build/outputs/apk/release/app-release.apk
-          asset_name: app-release.apk
-          asset_content_type: application/octet-stream
+          tag_name: ${{ steps.get_release.outputs.tag_name }}
+          files: |
+            app/build/outputs/apk/release/app-release.apk


### PR DESCRIPTION
- Replaces manual gradle caching with [setup-gradle](https://github.com/gradle/actions/tree/main/setup-gradle) action
- Use [action-gh-release](https://github.com/softprops/action-gh-release) action to create github releases and upload release assets
- Remove lint report annotation action as it doesn't add any value