### PR TITLE
Update outdated actions

### DIFF
--- a/workflow-templates/gcx-android-publish.yml
+++ b/workflow-templates/gcx-android-publish.yml
@@ -11,7 +11,7 @@ name: Publish Artifact
 
 on:
   release:
-    types: [released]
+    types: [ released ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,9 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project files
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Set up JDK 8
-        uses: actions/setup-java@v3.6.0
+        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
         with:
           distribution: 'adopt'
           java-version: 8

--- a/workflow-templates/gcx-android-pull-request.yml
+++ b/workflow-templates/gcx-android-pull-request.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project files
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Set up JDK 8
-        uses: actions/setup-java@v3.6.0
+        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
         with:
           distribution: 'adopt'
           java-version: 8
@@ -42,9 +42,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project files
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Set up JDK 8
-        uses: actions/setup-java@v3.6.0
+        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
         with:
           distribution: 'adopt'
           java-version: 8
@@ -56,7 +56,7 @@ jobs:
         run: ./gradlew testDebugUnitTest --continue
         timeout-minutes: 10
       - name: Annotate PR with JUnit Report
-        uses: mikepenz/action-junit-report@v3.5.2
+        uses: mikepenz/action-junit-report@db71d41eb79864e25ab0337e395c352e84523afe # v4.3.1
         if: always() # always run even if the previous step fails
         with:
           report_paths: '**/build/test-results/**/TEST-*.xml'
@@ -66,7 +66,7 @@ jobs:
         run: ./gradlew lintDebug
         timeout-minutes: 5
       - name: Upload test and lint reports
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: reports
           path: "**/build/reports/*"

--- a/workflow-templates/gcx-android-release-tag.yml
+++ b/workflow-templates/gcx-android-release-tag.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Set up JDK 8
-        uses: actions/setup-java@v3.6.0
+        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
         with:
           distribution: 'adopt'
           java-version: 8

--- a/workflow-templates/gcx-android-release.yml
+++ b/workflow-templates/gcx-android-release.yml
@@ -8,7 +8,7 @@ name: Build Release
 
 on:
   release:
-    types: [released]
+    types: [ released ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Set up JDK 8
-        uses: actions/setup-java@v3.6.0
+        uses: actions/setup-java@6a0805fcefea3d4657a47ac4c165951e33482018 # v4.2.2
         with:
           distribution: 'adopt'
           java-version: 8
@@ -36,7 +36,7 @@ jobs:
         timeout-minutes: 10
       - name: Get release
         id: get_release
-        uses: bruceadams/get-release@v1.3.2
+        uses: bruceadams/get-release@74c3d60f5a28f358ccf241a00c9021ea16f0569f # v1.3.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload release binary

--- a/workflow-templates/gcx-flutter-pull-request.yml
+++ b/workflow-templates/gcx-flutter-pull-request.yml
@@ -12,7 +12,7 @@ on:
     paths-ignore:
       - 'README.md'
   pull_request:
-    types: [opened, reopened, ready_for_review, synchronize]
+    types: [ opened, reopened, ready_for_review, synchronize ]
     paths-ignore:
       - 'README.md'
 
@@ -28,11 +28,11 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout project files
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Enable private dependencies
         run: git config --global url."https://${{ github.actor }}:${{ secrets.REPO_READ_TOKEN }}@github.com/".insteadOf "git@github.com:"
       - name: Cache dart packages
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: |
             /opt/hostedtoolcache/flutter
@@ -57,11 +57,11 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout project files
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Enable private dependencies
         run: git config --global url."https://${{ github.actor }}:${{ secrets.REPO_READ_TOKEN }}@github.com/".insteadOf "git@github.com:"
       - name: Cache dart packages
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: |
             /Users/runner/hostedtoolcache/flutter
@@ -84,11 +84,11 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout project files
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Enable private dependencies
         run: git config --global url."https://${{ github.actor }}:${{ secrets.REPO_READ_TOKEN }}@github.com/".insteadOf "git@github.com:"
       - name: Cache dart packages
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: |
             /opt/hostedtoolcache/flutter

--- a/workflow-templates/gcx-flutter-release-tag.yml
+++ b/workflow-templates/gcx-flutter-release-tag.yml
@@ -26,11 +26,11 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Enable private dependencies
         run: git config --global url."https://${{ github.actor }}:${{ secrets.REPO_READ_TOKEN }}@github.com/".insteadOf "git@github.com:"
       - name: Cache dart packages
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: |
             /opt/hostedtoolcache/flutter
@@ -56,7 +56,7 @@ jobs:
           ALIAS_PASSWORD: ${{ secrets.ALIAS_PASSWORD }}
         timeout-minutes: 10
       - name: Upload workflow artifact
-        uses: actions/upload-artifact@v3.1.1
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: apk
           path: "build/app/outputs/flutter-apk/app-release.apk"
@@ -67,9 +67,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Setup Codesign
-        uses: apple-actions/import-codesign-certs@v1
+        uses: apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d # v3
         with:
           keychain: signing_temp
           create-keychain: true
@@ -86,7 +86,7 @@ jobs:
       - name: Enable private dependencies
         run: git config --global url."https://${{ github.actor }}:${{ secrets.REPO_READ_TOKEN }}@github.com/".insteadOf "git@github.com:"
       - name: Cache dart packages
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         with:
           path: |
             /Users/runner/hostedtoolcache/flutter
@@ -102,7 +102,7 @@ jobs:
         run: ./flutterw build ipa --release --export-options-plist=ios/exportOptions.plist --build-number=${{ github.run_number }}
         timeout-minutes: 10
       - name: Upload workflow artifact
-        uses: actions/upload-artifact@v3.1.1
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: ipa
           path: "build/ios/ipa/myApp.ipa"
@@ -116,12 +116,12 @@ jobs:
       - build_release_ios
     steps:
       - name: Download workflow artifacts
-        uses: actions/download-artifact@v3.0.1
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           path: artifacts
       - name: Create GitHub release
         id: github_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/workflow-templates/gcx-ios-pull-request.yml
+++ b/workflow-templates/gcx-ios-pull-request.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches: [ develop, $default-branch ]
   pull_request:
-    types: [opened, reopened, ready_for_review, synchronize]
+    types: [ opened, reopened, ready_for_review, synchronize ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,7 +22,7 @@ jobs:
     if: github.event_name == 'push' || !github.event.pull_request.draft
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3.1.0
-    - name: Run tests
-      run: swift test -v
-      timeout-minutes: 10
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - name: Run tests
+        run: swift test -v
+        timeout-minutes: 10


### PR DESCRIPTION
Updates all actions and introduces [hash pinning](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)